### PR TITLE
Detect location of 'false' on slave OS and put it into public key command

### DIFF
--- a/ssh-copy-id.sh
+++ b/ssh-copy-id.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-# 
+#
 # File: ssh-copy-id.sh
 # Purpose: install SSH key in `~/.ssh/authorized_keys` detected tunnel sites
 #
@@ -20,7 +20,7 @@ check_access_and_set_exitcode() {
 ssh_copy_id() {
     info trying to add ssh key to remote authorized_keys file
     info 'you may be prompted for your remote password'
-    ssh $tunnelsite 'mkdir -p .ssh; cat >> .ssh/authorized_keys; chmod -R go-rwx .ssh' < $ssh_key_file.pub
+    ssh $tunnelsite "mkdir -p .ssh; sed -e \"s|__PATH_TO_FALSE__|\`which false\`|\" >> .ssh/authorized_keys; chmod -R go-rwx .ssh" < $ssh_key_file.pub
 }
 
 for tunnelsite in $tunnelsites; do
@@ -40,7 +40,7 @@ for tunnelsite in $tunnelsites; do
         fi
     elif test $exitcode = 1; then
         info 'Exit code was 1, most probably because the key is authorized'
-        info 'with the forced command /bin/false as expected.'
+        info 'with the forced command /bin/false or /usr/bin/false as expected.'
         confirmed_access=1
     else
         ssh_copy_id && recheck=1 || continue

--- a/ssh-keygen.sh
+++ b/ssh-keygen.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-# 
+#
 # File: ssh-keygen.sh
 # Purpose: create an SSH key without passphrase to use with autossh
 #   in screen, with restrictive options in the public key
@@ -15,7 +15,7 @@ else
     result ssh key file does NOT exist, creating now
     ssh-keygen -t rsa -C $ssh_key_comment -N '' -f $ssh_key_file
     info "adding restrictive options to public key"
-    sed -e "s/^/command=\"\/bin\/false\",no-agent-forwarding,no-X11-forwarding,no-pty /" $ssh_key_file.pub >$ssh_key_file.pub.bak && mv $ssh_key_file.pub.bak $ssh_key_file.pub
+    sed -e "s/^/command=\"__PATH_TO_FALSE__\",no-agent-forwarding,no-X11-forwarding,no-pty /" $ssh_key_file.pub >$ssh_key_file.pub.bak && mv $ssh_key_file.pub.bak $ssh_key_file.pub
 fi
 
 info contents of the public key: $ssh_key_file.pub


### PR DESCRIPTION
It seems that on linux false is in a different path than on BSD, this solves that problem by dynamically inserting the right path
